### PR TITLE
codegen: add support for CLI flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ swiftgen
 # Test binary, build with `go test -c`
 *.test
 
+# JSON artifacts
+*.json
+
 # Coverage data
 coverage.txt
 

--- a/internal/codegen/codegen_test.go
+++ b/internal/codegen/codegen_test.go
@@ -1,0 +1,78 @@
+// MIT License
+//
+// Copyright (c) 2023 Kevin Herro
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+package codegen
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGenerate(t *testing.T) {
+	// Create a temporary JSON schema file.
+	tempDirName := "/tmp/"
+	tempFile, err := os.CreateTemp(tempDirName, "schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDirName)
+
+	// Write the JSON schema to the temporary file.
+	jsonSchema := `{
+		"title": "Root",
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "age": { "type": "number" }
+        }
+    }`
+	if _, err := tempFile.Write([]byte(jsonSchema)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Close the temporary file.
+	if err := tempFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := "Schema.swift"
+
+	// Call Generate with the temporary file paths
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"cmd", "--src", tempFile.Name(), "--dest", dest}
+	if err := Generate(); err != nil {
+		t.Errorf("Generate() error = %v", err)
+	}
+	defer os.Remove(dest)
+
+	// Read the output file and check if it contains the generated code
+	generatedCode, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedProperties := []string{
+		"let Name: String?",
+		"let Age: Double?",
+	}
+
+	// Check if all expected properties are present in the generated code.
+	for _, property := range expectedProperties {
+		if !strings.Contains(string(generatedCode), property) {
+			t.Errorf("Generated code is missing property: %s\n\nGenerated code:\n\n%s", property, generatedCode)
+		}
+	}
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -40,7 +40,7 @@ type JSONSchemaToSwiftCodeGenerator struct {
 	Schema JSONSchema
 }
 
-func swiftType(jsonType, format string) string {
+func swiftType(jsonType string) string {
 	switch jsonType {
 	case "string":
 		return "String"
@@ -60,9 +60,9 @@ func swiftType(jsonType, format string) string {
 
 // convertToPascalCase converts an input string in snake_case or kebab-case
 // to PascalCase. It handles dashes and underscores as word separators.
-func convertToPascalCase(input string) string {
-	input = strings.Replace(input, "-", "_", -1)
-	words := strings.Split(input, "_")
+func convertToPascalCase(in string) string {
+	in = strings.Replace(in, "-", "_", -1)
+	words := strings.Split(in, "_")
 
 	// Convert each word to TitleCase using the title caser.
 	title := cases.Title(language.English)
@@ -74,34 +74,34 @@ func convertToPascalCase(input string) string {
 }
 
 func (g *JSONSchemaToSwiftCodeGenerator) Generate() string {
-	var code strings.Builder
+	var b strings.Builder
 
 	// Generate the struct definition.
-	structName := g.Schema.Title
-	code.WriteString(fmt.Sprintf("struct %s: Codable {\n", structName))
+	sName := g.Schema.Title
+	b.WriteString(fmt.Sprintf("struct %s: Codable {\n", sName))
 
 	// Generate properties.
-	for propertyName, property := range g.Schema.Properties {
-		swiftPropertyName := convertToPascalCase(propertyName)
-		swiftPropertyType := swiftType(property.Type, property.Format)
+	for pName, p := range g.Schema.Properties {
+		n := convertToPascalCase(pName)
+		t := swiftType(p.Type)
 
 		isRequired := false
 		for _, requiredProperty := range g.Schema.Required {
-			if requiredProperty == propertyName {
+			if requiredProperty == pName {
 				isRequired = true
 				break
 			}
 		}
 
 		if isRequired {
-			code.WriteString(fmt.Sprintf("\tlet %s: %s\n", swiftPropertyName, swiftPropertyType))
+			b.WriteString(fmt.Sprintf("\tlet %s: %s\n", n, t))
 		} else {
-			code.WriteString(fmt.Sprintf("\tlet %s: %s?\n", swiftPropertyName, swiftPropertyType))
+			b.WriteString(fmt.Sprintf("\tlet %s: %s?\n", n, t))
 		}
 	}
 
 	// Close the struct.
-	code.WriteString("}\n")
+	b.WriteString("}\n")
 
-	return code.String()
+	return b.String()
 }

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -22,21 +22,20 @@ import (
 func TestSwiftType(t *testing.T) {
 	tests := []struct {
 		jsonType string
-		format   string
 		expected string
 	}{
-		{"string", "", "String"},
-		{"integer", "", "Int"},
-		{"number", "", "Double"},
-		{"boolean", "", "Bool"},
-		{"array", "", "[String]"},
-		{"unknown", "", "Any"},
+		{"string", "String"},
+		{"integer", "Int"},
+		{"number", "Double"},
+		{"boolean", "Bool"},
+		{"array", "[String]"},
+		{"unknown", "Any"},
 	}
 
 	for _, test := range tests {
-		result := swiftType(test.jsonType, test.format)
+		result := swiftType(test.jsonType)
 		if result != test.expected {
-			t.Errorf("swiftType(%s, %s) = %s; want %s", test.jsonType, test.format, result, test.expected)
+			t.Errorf("swiftType(%s) = %s; want %s", test.jsonType, result, test.expected)
 		}
 	}
 }

--- a/internal/utils/tempfile.go
+++ b/internal/utils/tempfile.go
@@ -12,19 +12,16 @@
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
 
-// Package tempfile...
-package tempfile
+package utils
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 )
 
 // NewTempFile returns a new output file in dir with the provided prefix and suffix.
-func NewTempFile(dir, prefix string) (*os.File, error) {
-	suffix := ".swift"
+func NewTempFile(dir, prefix, suffix string) (*os.File, error) {
 	switch f, err := os.OpenFile(filepath.Join(dir, fmt.Sprintf("%s%s", prefix, suffix)), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666); {
 	case err == nil:
 		return f, nil
@@ -33,28 +30,4 @@ func NewTempFile(dir, prefix string) (*os.File, error) {
 	}
 	// "Just give up!" - Mr. S
 	return nil, fmt.Errorf("could not create file of the form %s%s", prefix, suffix)
-}
-
-var tempFiles []string
-var tempFilesMu = sync.Mutex{}
-
-// deferDeleteTempFile marks a file to be deleted by the next call to Cleanup().
-func deferDeleteTempFile(path string) {
-	tempFilesMu.Lock()
-	tempFiles = append(tempFiles, path)
-	tempFilesMu.Unlock()
-}
-
-// cleanupTempFiles removes any temporary files selected for deferred cleanup.
-func cleanupTempFiles() error {
-	tempFilesMu.Lock()
-	defer tempFilesMu.Unlock()
-	var lastErr error
-	for _, f := range tempFiles {
-		if err := os.Remove(f); err != nil {
-			lastErr = err
-		}
-	}
-	tempFiles = nil
-	return lastErr
 }

--- a/internal/utils/tempfile_test.go
+++ b/internal/utils/tempfile_test.go
@@ -12,7 +12,7 @@
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
 
-package tempfile
+package utils
 
 import (
 	"os"
@@ -31,14 +31,15 @@ func TestNewTempFile(t *testing.T) {
 
 	// Call NewTempFile with the temporary directory and prefix.
 	prefix := "testfile"
-	f, err := NewTempFile(tmpDir, prefix)
+	suffix := ".swift"
+	f, err := NewTempFile(tmpDir, prefix, suffix)
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
 	defer f.Close()
 
 	// Verify that the file was created with the expected name.
-	expectedName := filepath.Join(tmpDir, prefix+".swift")
+	expectedName := filepath.Join(tmpDir, prefix+suffix)
 	if got := f.Name(); got != expectedName {
 		t.Errorf("unexpected file name: got %q, expected %q", got, expectedName)
 	}
@@ -57,24 +58,5 @@ func TestNewTempFile(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(content)); got != expectedContent {
 		t.Errorf("unexpected file content: got %q, expected %q", got, expectedContent)
-	}
-}
-
-func TestCleanupTempFiles(t *testing.T) {
-	// Create a temporary file.
-	f, err := NewTempFile("", "example")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
-	deferDeleteTempFile(f.Name())
-	defer f.Close()
-
-	// Call cleanupTempFiles and verify that the file has been deleted.
-	if err := cleanupTempFiles(); err != nil {
-		t.Errorf("failed to cleanup temp files: %v", err)
-	}
-	_, err = os.Stat(f.Name())
-	if !os.IsNotExist(err) {
-		t.Errorf("expected temp file to be deleted, but it still exists")
 	}
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,49 @@
+// MIT License
+//
+// Copyright (c) 2023 Kevin Herro
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// Package utils implements methods used throughout swiftgen.
+package utils
+
+import "strings"
+
+// SplitBefore slices s into all substrings before the first instance of sep and
+// returns a slice of those substrings.
+//
+// If s does not contain sep and sep is not empty, SplitBefore returns
+// a slice of length 1 whose only element is s.
+//
+// If s or sep are empty, SplitBefore returns an empty slice.
+func SplitBefore(s string, sep string) []string {
+	if len(sep) == 0 || len(s) == 0 {
+		return []string{s}
+	}
+
+	var result []string
+	index := strings.Index(s, sep)
+	if index != -1 {
+		if index > 0 {
+			result = append(result, s[:index])
+		}
+		result = append(result, s[index:])
+	} else {
+		result = append(result, s)
+	}
+
+	// s does not contain sep.
+	if len(result) == 0 {
+		return []string{s}
+	}
+
+	return result
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,45 @@
+// MIT License
+//
+// Copyright (c) 2023 Kevin Herro
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitBefore(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		sep      string
+		expected []string
+	}{
+		{"Basic", "Schema.swift", ".", []string{"Schema", ".swift"}},
+		{"No separator", "Schema", ".", []string{"Schema"}},
+		{"Separator not found", "Schema.swift", "*", []string{"Schema.swift"}},
+		{"Empty input", "", ".", []string{""}},
+		{"Empty separator", "Schema.swift", "", []string{"Schema.swift"}},
+		{"Empty input and separator", "", "", []string{""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SplitBefore(tt.input, tt.sep)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("SplitBefore(%q, %q) = %v, want %v", tt.input, tt.sep, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds support for two CLI flags:
- `--src`: the path to the JSON schema file,
- `--dest`: the path to the write location

Usage: `swiftgen --src schema.json --dest /foo/bar/baz/Schema.swift`